### PR TITLE
Fix shell quoting of phpenv-install message after install

### DIFF
--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -81,6 +81,6 @@ create_phpenv_bin "$PHPENV_ROOT"
 echo "Success."
 echo
 echo "Now add $PHPENV_ROOT/bin to your \$PATH, add \
-\"eval \$(phpenv init -)\" at the end of your ~/.bashrc \
+'eval \"\$(phpenv init -)\"' at the end of your ~/.bashrc \
 and restart your shell to use phpenv."
 echo


### PR DESCRIPTION
After installing phpenv, the phpenv-install tells such as:

```
Now add ~/.phpenv/bin to your $PATH, add "eval $(phpenv init -)" at the end of your ~/.bashrc and restart your shell to use phpenv.
```

However, `eval "$(phpenv init -)"` is correct.
