### PR TITLE
Add an extensions directory with conig-add and config-rm commands

### DIFF
--- a/extensions/rbenv-config-add
+++ b/extensions/rbenv-config-add
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+PHPENV_VERSION_NAME="$(rbenv-version-name)"
+PHPENV_CONFIG_PATH="${RBENV_ROOT}/versions/${PHPENV_VERSION_NAME}/etc/conf.d"
+PHPENV_CONFIG_FILE=$1
+
+if [ -f $PHPENV_CONFIG_FILE ]; then
+  cp "$PHPENV_CONFIG_FILE" "$PHPENV_CONFIG_PATH"
+  echo "File $PHPENV_CONFIG_FILE added to $PHPENV_CONFIG_PATH."
+else
+  echo "File $PHPENV_CONFIG_FILE does no exist."
+  exit 1
+fi

--- a/extensions/rbenv-config-rm
+++ b/extensions/rbenv-config-rm
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+PHPENV_VERSION_NAME="$(rbenv-version-name)"
+PHPENV_CONFIG_PATH="${RBENV_ROOT}/versions/${PHPENV_VERSION_NAME}/etc/conf.d"
+
+# Provide rbenv completions
+if [ "$1" = "--complete" ]; then
+  exec ls "$PHPENV_CONFIG_PATH"
+fi
+
+PHPENV_CONFIG_FILE=$1
+
+if [ -f $PHPENV_CONFIG_FILE ]; then
+  rm "${PHPENV_CONFIG_PATH}/$1"
+  echo "File $PHPENV_CONFIG_FILE removed from $PHPENV_CONFIG_PATH."
+else
+  echo "File $PHPENV_CONFIG_FILE does no exist."
+  exit 1
+fi


### PR DESCRIPTION
Hi Chirstoph,

As mentioned in travis-ci/travis-ci#511, I extended phpenv with two commands that allow to add (or remove) custom configuration files to the `conf.d` directory of the currently used PHP version:
- `phpenv config-add`
- `phpenv config-rm`

Right now phpenv is a simple and standalone install script, so I put these commands in an `extensions` directory. Users can then manually take these extensions and copy them in their own rbenv installation directory if needed. This procedure should however be documented: I can take care of this documentation if you agree to integrate these extensions directly into phpenv's repository.

If you think that it does not make sense to supply these two commands with phpenv, I of course won't take it badly and I'll consider embedding them as extensions to phpenv in Travis directly :smiley: 
