### PR TITLE
be copyable to use

### DIFF
--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -80,7 +80,9 @@ create_phpenv_bin "$PHPENV_ROOT"
 
 echo "Success."
 echo
-echo "Now add $PHPENV_ROOT/bin to your \$PATH, add \
-'eval \"\$(phpenv init -)\"' at the end of your ~/.bashrc \
+echo "export PATH=\"${PHPENV_ROOT}/bin:"'$PATH"'
+echo 'eval "$(phpenv init -)"'
+echo
+echo "Add above line at the end of your ~/.bashrc \
 and restart your shell to use phpenv."
 echo


### PR DESCRIPTION
hi @CHH. Thanks for phpenv, and php-build.
just tiny fix for more copyable to use.
Thanks.
### before:

```
Success.

Now add /home/ec2-user/.phpenv/bin to your $PATH, add 'eval "$(phpenv init -)"' at the end of your ~/.bashrc and restart your shell to use phpenv.

```
### after:

```
Success.

export PATH="/Users/banyan/.phpenv/bin:$PATH"
eval "$(phpenv init -)"

Add above line at the end of your ~/.bashrc and restart your shell to use phpenv.

```
