### PR TITLE
Add information about system-wide install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Sets up a separate rbenv environment for PHP
 
 ## SYNOPSIS
 
-    phpenv-install.sh
-    UPDATE=yes phpenv-install.sh
+    $ phpenv-install.sh
+    $ UPDATE=yes phpenv-install.sh
+    $ PHPENV_ROOT=/usr/local/phpenv phpenv-install.sh
 
 ## DESCRIPTION
 
@@ -48,6 +49,18 @@ Finally, enable phpenv in your shell by adding `$HOME/.phpenv/bin` and
 `$HOME/.phpenv/shims` to your `PATH` and adding `eval "$(phpenv init -)"`
 to your `$HOME/.bash_profile` or `$HOME/.bashrc` (or your shell's 
 respective file) and restart your shell.
+
+### SYSTEM WIDE INSTALL
+
+Using `phpenv` as system wide install,
+`PHPENV_ROOT` environment variable before
+calling `phpenv-install.sh`, for example:
+
+    $ PHPENV_ROOT=/usr/local/phpenv ./phpenv-install.sh
+
+You can also check as reference how to install phpenv system-wide.
+See: [phpenv-install-system-wide.sh](https://gist.github.com/banyan/4715950)
+
 
 ## IMPORTANT NOTES
 


### PR DESCRIPTION
Even though I'm familiar with `rbenv`, when I saw `phpenv` at first, I was confused a little bit to understand about that  `phpenv` is nothing but tiny wrapper of `rbenv` entirely.

I felt like what is `PHPENV_ROOT` and how `RBENV_ROOT` does a meaningful for `phpenv` . Once I know, It's  simple to understand, and I love the way what you selected.

Since `phpenv` is a great tool, it's suitable not only development tool but also production-use.
So I add tiny tips to README how to install `phpenv` as system-wide to grasp how `phpenv` works.

I'm not sure whether you feel it's not the way as you intended, then it's OK.
Thanks!
