### PR TITLE
Use a phpenv specific filename for local version selection

### DIFF
--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -73,6 +73,10 @@ else
     if [ "$CHECKOUT" = "yes" ]; then
         clone_rbenv "$PHPENV_ROOT"
         sed -i -e 's/rbenv/phpenv/g' "$PHPENV_ROOT"/completions/rbenv.{bash,zsh}
+        sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$PHPENV_ROOT"/libexec/rbenv-local
+        sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$PHPENV_ROOT"/libexec/rbenv-version-file
+        sed -i -s 's/\.ruby-version/.php-version/g' "$PHPENV_ROOT"/libexec/rbenv-local
+        sed -i -s 's/\.ruby-version/.php-version/g' "$PHPENV_ROOT"/libexec/rbenv-version-file
     fi
 fi
 


### PR DESCRIPTION
Appreciate this probably breaks BC, but it saves me from getting 

```
Unknown ruby interpreter version: '5.4.8'
```

every time I move in to a directory where I'm using phpenv rather than rbenv. 

I don't know what's invoking ruby when I move in to a dir, but it's probably something to do with oh-my-zsh.
