### PR TITLE
Bug: phpenv shell not found on the ubuntu

### DIFF
--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -30,7 +30,8 @@ phpenv_script() {
 
     cat <<SH
 #!/usr/bin/env bash
-export RBENV_ROOT='$root'
+export PHPENV_ROOT=\${PHPENV_ROOT:-'$root'}
+export RBENV_ROOT="\$PHPENV_ROOT"
 exec "\$RBENV_ROOT/libexec/rbenv" "\$@"
 SH
 }
@@ -77,6 +78,8 @@ else
         sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$PHPENV_ROOT"/libexec/rbenv-version-file
         sed -i -s 's/\.ruby-version/.php-version/g' "$PHPENV_ROOT"/libexec/rbenv-local
         sed -i -s 's/\.ruby-version/.php-version/g' "$PHPENV_ROOT"/libexec/rbenv-version-file
+        sed -i -e 's/\(^\|[^/]\)rbenv/\1phpenv/g' "$PHPENV_ROOT"/libexec/rbenv-init
+        sed -i -e 's/\phpenv-commands/rbenv-commands/g' "$PHPENV_ROOT"/libexec/rbenv-init
     fi
 fi
 


### PR DESCRIPTION
Hi, I have fixed the issue that the `phpenv shell` command not found on the ubuntu refer to issue #24 . Please kindly merge to master. Or let me know if it have to fix anything.

Include commited from @Milly - Pull Request #13
Refer to Issue : https://github.com/CHH/phpenv/issues/24
