### PR TITLE
Remove all mentioning of rbenv from phpenv output

### DIFF
--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -121,5 +121,5 @@ and restart your shell to use phpenv."
 echo
 echo "For bash completion support, also include the following line:"
 echo
-echo "source \"${PHPENV_ROOT}/completion/phpenv.bash\""
+echo "source \"${PHPENV_ROOT}/completions/phpenv.bash\""
 echo

--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -28,7 +28,7 @@ PHPENV_REPO="https://github.com/chh/phpenv"
 
 phpenv_script() {
     local root="$1"
-    
+
     cat <<SH
 #!/usr/bin/env bash
 export PHPENV_ROOT=\${PHPENV_ROOT:-'$root'}
@@ -39,7 +39,7 @@ SH
 
 create_phpenv_bin() {
     local install_location="$1"
-    
+
     phpenv_script "$install_location" > "$install_location/bin/phpenv"
     chmod +x "$install_location/bin/phpenv"
 }
@@ -62,31 +62,31 @@ clone_rbenv() {
 phpenvify() {
     local install_location="$1"
     local cwd=$(pwd)
-    
+
     rev="$(cd "$(dirname "$0")" && git rev-parse --short HEAD)"
-    
+
     cd "$install_location"
-    
+
     rm -f bin/rbenv bin/ruby-local-exec
-    
+
     # Create file phpenv prefixed copies of the original rbenv files
     for f in completions/rbenv* libexec/rbenv*; do
         cp -a "$f" "${f/rbenv/phpenv}"
     done
-    
+
     # Remove all rbenv/Ruby from phpenv prefixed files
     sed --in-place -e 's/rbenv/phpenv/g' -e 's/RBENV/PHPENV/g' -e 's/Ruby/PHP/g' completions/phpenv* libexec/phpenv*
-    
+
     # Fix the version
     cat <<SH > libexec/phpenv---version
 #!/bin/sh
 echo "phpenv $rev - based on \`$PHPENV_ROOT/libexec/rbenv---version\`"
 SH
     chmod a+x libexec/phpenv---version
-    
+
     # Fix link in help text:
     sed --in-place -e "s|^.*For full documentation.*\$|  echo \"For full documentation, see:\"\n  echo \" rbenv: ${RBENV_REPO}#readme\"\n  echo \" phpenv: ${PHPENV_REPO}#readme\"|" libexec/phpenv-help
-    
+
     cd "$cwd"
 }
 

--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -58,6 +58,20 @@ clone_rbenv() {
     git clone "$RBENV_REPO" "$install_location" > /dev/null
 }
 
+phpenvify() {
+    local install_location="$1"
+    local cwd=$(pwd)
+    cd "$install_location"
+    
+    for f in bin/rbenv* completions/rbenv* libexec/rbenv*; do
+        cp -va "$f" "${f/rbenv/phpenv}"
+    done
+    
+    sed --in-place -e 's/rbenv/phpenv/g' -e 's/RBENV/PHPENV/g' -e 's/Ruby/PHP/g' bin/phpenv* completions/phpenv* libexec/phpenv*
+    
+    cd "$cwd"
+}
+
 if [ -z "$PHPENV_ROOT" ]; then
     PHPENV_ROOT="$HOME/.phpenv"
 fi
@@ -73,14 +87,7 @@ else
     echo "Installing phpenv in $PHPENV_ROOT"
     if [ "$CHECKOUT" = "yes" ]; then
         clone_rbenv "$PHPENV_ROOT"
-        sed -i -e 's/rbenv/phpenv/g' "$PHPENV_ROOT"/completions/rbenv.{bash,zsh}
-        sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$PHPENV_ROOT"/libexec/rbenv-local
-        sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$PHPENV_ROOT"/libexec/rbenv-version-file
-        sed -i -s 's/\.ruby-version/.php-version/g' "$PHPENV_ROOT"/libexec/rbenv-local
-        sed -i -s 's/\.ruby-version/.php-version/g' "$PHPENV_ROOT"/libexec/rbenv-version-file
-        sed -i -e 's/\(^\|[^/]\)rbenv/\1phpenv/g' "$PHPENV_ROOT"/libexec/rbenv-init
-        sed -i -e 's/\phpenv-commands/rbenv-commands/g' "$PHPENV_ROOT"/libexec/rbenv-init
-        sed -i -e 's/\Ruby/PHP/g' "$PHPENV_ROOT"/libexec/rbenv-which
+        phpenvify "$PHPENV_ROOT"
     fi
 fi
 


### PR DESCRIPTION
Hi Christoph,

my patch replaces all mentioning of rbenv from phpenv (but keeps a reference to rbenv in the help text). Please consider including the patch, thx.

Greets,
Dennis
