### PR TITLE
Replace RBENV_VERSION with PHPENV_VERSION variable (Depends on fix-update)

### DIFF
--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -48,6 +48,7 @@ update_phpenv() {
     local cwd=$(pwd)
     cd "$install_location"
 
+    git checkout .
     git pull origin master
 
     cd "$cwd"
@@ -82,6 +83,7 @@ fi
 if [ "$UPDATE" = "yes" ]; then
     echo "Updating phpenv in $PHPENV_ROOT"
     update_phpenv "$PHPENV_ROOT"
+    replace_rbenv "$PHPENV_ROOT"
 else
     echo "Installing phpenv in $PHPENV_ROOT"
     if [ "$CHECKOUT" = "yes" ]; then

--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -58,6 +58,19 @@ clone_rbenv() {
     git clone "$RBENV_REPO" "$install_location" > /dev/null
 }
 
+replace_rbenv() {
+    local install_location="$1"
+
+    sed -i -e 's/rbenv/phpenv/g' "$install_location"/completions/rbenv.{bash,zsh}
+    sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$install_location"/libexec/rbenv-local
+    sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$install_location"/libexec/rbenv-version-file
+    sed -i -s 's/\.ruby-version/.php-version/g' "$install_location"/libexec/rbenv-local
+    sed -i -s 's/\.ruby-version/.php-version/g' "$install_location"/libexec/rbenv-version-file
+    sed -i -e 's/\(^\|[^/]\)rbenv/\1phpenv/g' "$install_location"/libexec/rbenv-init
+    sed -i -e 's/\phpenv-commands/rbenv-commands/g' "$install_location"/libexec/rbenv-init
+    sed -i -e 's/\Ruby/PHP/g' "$install_location"/libexec/rbenv-which
+}
+
 if [ -z "$PHPENV_ROOT" ]; then
     PHPENV_ROOT="$HOME/.phpenv"
 fi
@@ -73,14 +86,7 @@ else
     echo "Installing phpenv in $PHPENV_ROOT"
     if [ "$CHECKOUT" = "yes" ]; then
         clone_rbenv "$PHPENV_ROOT"
-        sed -i -e 's/rbenv/phpenv/g' "$PHPENV_ROOT"/completions/rbenv.{bash,zsh}
-        sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$PHPENV_ROOT"/libexec/rbenv-local
-        sed -i -s 's/\.rbenv-version/.phpenv-version/g' "$PHPENV_ROOT"/libexec/rbenv-version-file
-        sed -i -s 's/\.ruby-version/.php-version/g' "$PHPENV_ROOT"/libexec/rbenv-local
-        sed -i -s 's/\.ruby-version/.php-version/g' "$PHPENV_ROOT"/libexec/rbenv-version-file
-        sed -i -e 's/\(^\|[^/]\)rbenv/\1phpenv/g' "$PHPENV_ROOT"/libexec/rbenv-init
-        sed -i -e 's/\phpenv-commands/rbenv-commands/g' "$PHPENV_ROOT"/libexec/rbenv-init
-        sed -i -e 's/\Ruby/PHP/g' "$PHPENV_ROOT"/libexec/rbenv-which
+        replace_rbenv "$PHPENV_ROOT"
     fi
 fi
 

--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -48,7 +48,7 @@ update_phpenv() {
     local cwd=$(pwd)
     cd "$install_location"
 
-    git pull origin master &> /dev/null
+    git pull origin master
 
     cd "$cwd"
 }

--- a/bin/phpenv-install.sh
+++ b/bin/phpenv-install.sh
@@ -70,6 +70,7 @@ replace_rbenv() {
     sed -i -e 's/\(^\|[^/]\)rbenv/\1phpenv/g' "$install_location"/libexec/rbenv-init
     sed -i -e 's/\phpenv-commands/rbenv-commands/g' "$install_location"/libexec/rbenv-init
     sed -i -e 's/\Ruby/PHP/g' "$install_location"/libexec/rbenv-which
+    sed -i -e 's/RBENV_VERSION/PHPENV_VERSION/g' "$PHPENV_ROOT"/libexec/rbenv-*
 }
 
 if [ -z "$PHPENV_ROOT" ]; then


### PR DESCRIPTION
This will replace RBENV_VERSION with PHPENV_VERSION so you can separately specify PHP and Ruby versions.

Note: this will break any plugins or supporting scripts that assume phpenv uses RBENV_VERSION ([phpenv-composer](https://github.com/ngyuki/phpenv-composer) being one)
